### PR TITLE
Add support for 3 entities

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Lovelace Dual Thermostat Card
 
-A custom Lovelace card based on the native thermostat card that allows to control dual thermostats that create separate Heat and Cool entities.
+A custom Lovelace card based on the native thermostat card that allows to control thermostats that have separate Heat and Cool entities
 
 Heat and Cool entities are updated depending on the active thermostat mode. The low point on the Auto mode controls the heat entity and the high point controls the cool entity allowing you to use a single card for both entities.
 
@@ -19,7 +19,7 @@ Heat and Cool entities are updated depending on the active thermostat mode. The 
 ## Available configuration options:
 
 * `entities` *array*
-  * Using entity objects:
+  * Using entity objects: (only supports a cool and heat entity)
 	 * `entity` *string*: The thermostat entity id **required**
     * `type` *string*: cool or heat **required**
   * Using string notation (Cooling entity first):
@@ -48,15 +48,16 @@ cards:
     max_slider: 80
 ```
 
-#### Using string (First provided entity will define to the cool entity)
+#### Using string (First provided entity will define to the state display entity, second will be cool)
 
 ```yaml
 cards:
   - type: custom:dual-thermostat
     name: Downstairs
     entities:
-      - climate.downstairs_cool
-      - climate.downstairs_heat
+      - climate.downstairs
+      - climate.downstairs_coolfrom
+      - climate.downstairs_heatto
     fan_control: true
     min_slider: 60
     max_slider: 80

--- a/src/app.js
+++ b/src/app.js
@@ -101,8 +101,13 @@ class DualThermostatCard extends LitElement {
     }
 
     if (Object.keys(output).length == 0) {
-      output['cool'] = entities[0];
-      output['heat'] = entities[1];
+      if(entities.length == 2) {
+         output['cool'] = entities[0];
+         output['heat'] = entities[1];
+      } else {     // if there are 3 or more entities use 2 and 3 as the cool and heat values only
+         output['cool'] = entities[1];
+         output['heat'] = entities[2];        
+      }
     }
 
     return output;


### PR DESCRIPTION
Change the entities so that you can have a state entity for display/control and then 2 others for cool/heat.
NOTE: Only the temperatures/value of cool and heat entities will be used/set, display will only ever be the first entity given be shown
ADDITIONAL NOTE: This card does not handle the automation/scripts that are required to apply the changes to the base state entity.